### PR TITLE
Validate template is string when baking

### DIFF
--- a/mold.js
+++ b/mold.js
@@ -15,6 +15,9 @@ function Mold(env) {
 
 Mold.prototype.bake = function(name, string) {
   if (string == null) { string = name; name = null }
+  if (typeof string !== "string")
+    throw new TypeError("Mold template must be a string")
+
   var template = new Template(string, name)
   var result = evaluate(compile(template), this)
   if (name) this.defs[name] = result

--- a/test.js
+++ b/test.js
@@ -47,6 +47,15 @@ test("define", function() {
   eq(m.bake("<<paren 10>><<sub 20>>")(), "(10)[20]");
 });
 
+test("validate", function() {
+  try {
+    m.bake(Buffer.from("Some content"))
+    throw new Error("Should not run")
+  } catch (err) {
+    eq(err.message, "Mold template must be a string")
+  }
+})
+
 // DRIVER CODE
 
 function Failure(why) {this.message = why;}


### PR DESCRIPTION
If you directly pass an undecoded Buffer into `bake`, it throws an error only on `dispatch`, making it very hard to trace the original bug. This has tripped me up several times already (with some months in between). Added some validation to protect future me against this same mistake.

I don't think this is a breaking change, as it should only throw in code that's already broken.