### PR TITLE
Support defs with multiple arguments

### DIFF
--- a/mold.js
+++ b/mold.js
@@ -35,10 +35,11 @@ Mold.prototype.forEachIn = function(obj, f) {
   for (var n in obj) if (hop.call(obj, n)) f(n, obj[n], i++)
 }
 
-Mold.prototype.dispatch = function(name, arg) {
+Mold.prototype.dispatch = function(name) {
   if (!(name in this.defs))
     throw new Error("Unrecognised template command: '" + name + "'.")
-  return this.defs[name](arg)
+  var args = Array.prototype.slice.call(arguments, 1)
+  return this.defs[name].apply(this.defs, args)
 }
 
 

--- a/test.js
+++ b/test.js
@@ -43,8 +43,9 @@ test("ctx", function() {
 
 test("define", function() {
   m.defs.paren = function(a) {return "(" + a + ")"}
+  m.defs.sum = function(a, b) {return a + b}
   m.bake("sub", "[<<t $in>>]")
-  eq(m.bake("<<paren 10>><<sub 20>>")(), "(10)[20]");
+  eq(m.bake("<<paren 10>><<sub 20>> <<sum 1, 2>>")(), "(10)[20] 3");
 });
 
 test("validate", function() {


### PR DESCRIPTION
This allows directives added to `mold.defs` as functions to use multiple arguments. The template syntax for this would be `<<def $in.first, $in.second>>`. I didn't have to make any changes to the compiler to support this. All that was needed was to make sure that the `dispatch` method can pass on an arbitrary amount of args instead of just the one.